### PR TITLE
Fixed HC blindfold property display in pair permissions UI

### DIFF
--- a/client-primer/UI/UiWardrobe/RestraintSetEditor.cs
+++ b/client-primer/UI/UiWardrobe/RestraintSetEditor.cs
@@ -490,7 +490,7 @@ public class RestraintSetEditor : IMediatorSubscriber
                     UiSharedService.AttachToolTip("Enables the Blinded property for this set." +
                         Environment.NewLine + "Restricts use of any actions which rely on your sight to execute.");
                     ImGui.SameLine(0, 2);
-                    _uiShared.BooleanToColoredIcon(properties.LegsRestrained, false);
+                    _uiShared.BooleanToColoredIcon(properties.Blindfolded, false);
 
                     using (ImRaii.Disabled(!pair.UserPairOwnUniquePairPerms.InHardcore))
                     {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cc55e2ac-f434-42f5-beac-2ce8adda70ea)

Fixes the UI to correctly reflect the blindfold status next to the blindfold button.